### PR TITLE
Add BunkerWeb to Security section

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,6 +41,10 @@ This list is maintained by [Frederic Cambus](https://www.cambus.net). For update
 - [Gixy - Nginx configuration static analyzer](https://github.com/yandex/gixy)
 - [Nginx common configuration - Universal config and snippets](https://github.com/tldr-devops/nginx-common-configuration)
 
+## Security
+
+- [BunkerWeb - Next-generation, open-source Web Application Firewall (WAF) based on Nginx](https://www.bunkerweb.io)
+
 ## Tutorials
 
 - [NGINX and NGINX Plus Admin Guide](https://docs.nginx.com/nginx/admin-guide/)


### PR DESCRIPTION
## Description
This PR adds [BunkerWeb](https://www.bunkerweb.io) to the list.
I noticed there wasn't a dedicated "Security" section, so I created one to better categorize this resource and potentially others in the future.

## Changes
- Created a new `## Security` section in the README.md.
- Added `BunkerWeb` entry to the new section.

## Checklist
- [x] The link is valid.
- [x] The entry is in the correct format.
