### PR TITLE
Add Webinoly to Tools section

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,6 +45,10 @@ This list is maintained by [Frederic Cambus](https://www.cambus.net). For update
 
 - [BunkerWeb - Next-generation, open-source Web Application Firewall (WAF) based on Nginx](https://www.bunkerweb.io)
 
+## Tools
+
+- [Webinoly - Production Nginx and PHP made simple: terminal-first, performance-obsessed, and secure by default.](https://webinoly.com)
+
 ## Tutorials
 
 - [NGINX and NGINX Plus Admin Guide](https://docs.nginx.com/nginx/admin-guide/)


### PR DESCRIPTION
### Description
This PR adds [Webinoly](https://webinoly.com/) to the list.
I noticed there wasn't a dedicated "Tools" section, so I created one to better categorize this resource and potentially others in the future.

### Changes
- Created a new ## Tools section in the README.md.
- Added Webinoly entry to the new section.

### Checklist
- [x] The link is valid.
- [x] The entry is in the correct format.