### PR TITLE
Add article: The State of Nginx Modules on Debian and Ubuntu in 2026

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,6 +60,7 @@ This list is maintained by [Frederic Cambus](https://www.cambus.net). For update
 - [Using New Debugging Features to Probe NGINX Internals](https://www.nginx.com/blog/new-debugging-features-probe-nginx-internals/)
 - [Performing A/B Testing with NGINX and NGINX Plus](https://www.nginx.com/blog/performing-a-b-testing-nginx-plus/)
 - [Improving NGINX Performance with Kernel TLS and SSL_sendfile()](https://www.nginx.com/blog/improving-nginx-performance-with-kernel-tls/)
+- [The State of Nginx Modules on Debian and Ubuntu in 2026](https://www.blendbyte.com/blog/the-state-of-nginx-modules-on-debian-and-ubuntu-in-2026)
 
 ## Modules development
 


### PR DESCRIPTION
Adds a link to [The State of Nginx Modules on Debian and Ubuntu in 2026](https://www.blendbyte.com/blog/the-state-of-nginx-modules-on-debian-and-ubuntu-in-2026) under Tutorials.

The article covers the shutdown of Ondřej Surý's nginx apt repository (mainline retired summer 2025, stable removed April 2026), what options remain for prebuilt dynamic modules on Debian and Ubuntu, and the trade-offs between distro packages, nginx.org's official repo, compiling from source, and third-party module repositories.

Thought it'd be a useful reference for anyone running nginx with modules like brotli, geoip2, or headers-more on Debian/Ubuntu and wondering where to get them now that Sury's repo is gone.